### PR TITLE
Fixed RerefenceError for 'parser' variable under strict mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var accval = require('accidental-value');
 module.exports = function scientific(name) {
   var format = /^([a-h])(x|#|bb|b?)(-?\d*)/i;
 
-  parser = name.match(format);
+  var parser = name.match(format);
   if (!(parser && name === parser[0] && parser[3].length)) return;
 
   var noteName = parser[1];


### PR DESCRIPTION
Hi! 
First of all - big thanks for "teoria", it's a real thing.

I'm about to use it in my projects, which I build under strict mode, and this missing 'var' stays in my way.
Please, merge it into master so that I could continue without pulling my hair out.
Thanks!
